### PR TITLE
PJ-94 set browsers to return json responses for tokens and disable admin url

### DIFF
--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
-from .views import plans, users
-from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
+
+from .views import plans, users, tokens
 
 # Framework-generated: 5%
 # Human-written: 75%
@@ -10,8 +10,8 @@ urlpatterns = [
     path('profile/', users.get_user_profile, name='get_user_profile'),
     
     # JWT authentication endpoints
-    path('token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
-    path('token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+    path('token/', tokens.JSONTokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('token/refresh/', tokens.JSONTokenRefreshView.as_view(), name='token_refresh'),
     
     # Plans endpoints
     path('plans/add', plans.create_plan, name='create-plan')

--- a/backend/api/views/tokens.py
+++ b/backend/api/views/tokens.py
@@ -1,0 +1,17 @@
+# Framework-generated: 0%
+# Human-written: 0%
+# AI-generated: 100% 
+#   - override token api view with JSON responses - https://chatgpt.com/share/68dc2d36-9910-8008-b4c0-05ea89493638
+
+from rest_framework.renderers import JSONRenderer
+from rest_framework_simplejwt.views import (
+    TokenObtainPairView,
+    TokenRefreshView,
+)
+
+# Subclass and override renderer_classes
+class JSONTokenObtainPairView(TokenObtainPairView):
+    renderer_classes = [JSONRenderer]
+
+class JSONTokenRefreshView(TokenRefreshView):
+    renderer_classes = [JSONRenderer]

--- a/backend/app/urls.py
+++ b/backend/app/urls.py
@@ -21,7 +21,7 @@ from django.contrib import admin
 from django.urls import path, include
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
+    #path('admin/', admin.site.urls),
     path('api/', include('api.urls')),
 ]
 


### PR DESCRIPTION
https://cs673-team3.atlassian.net/jira/software/c/projects/PJ/boards/3?selectedIssue=PJ-94

Viewing the following backend urls on a web browser should render the followings instead of a POST web form: 

/api/token   -----> JSON response
/api/token/refresh   -----> JSON response
/admin -----> 404 Not Found